### PR TITLE
Allows embedIcons to be applied only to a specific branch of the DOM

### DIFF
--- a/static/grunticon.embed.js
+++ b/static/grunticon.embed.js
@@ -53,7 +53,10 @@
 
 	// embed an icon of a particular name ("icon-foo") in all elements with that icon class
 	// and remove its background image
-	var embedIcons = function(icons){
+	var embedIcons = function(icons, rootNode){
+		// default is to embed icons for all matching nodes in document
+		rootNode = rootNode || document;
+
 		var selectedElems, filteredElems, embedAttr, selector;
 
 		// attr to specify svg embedding
@@ -64,7 +67,7 @@
 
 			try {
 				// get ALL of the elements matching the selector
-				selectedElems = document.querySelectorAll( selector );
+				selectedElems = rootNode.querySelectorAll( selector );
 			} catch (er) {
 				// continue further with embeds even though it failed for this icon
 				continue;


### PR DESCRIPTION
This pull request enables embedIcons to be selectively applied to specific branches of the DOM tree.

The reason I propose this change is to provide a more efficient way of embedding icons when the DOM is being mutated frequently (in my case, by React.js) by targeting specific nodes when the SVGs are inserted.

Without this change, I would have to have each react component that consumes grunticon svgs to call embedicons, which would in turn traverse the entire DOM tree.

With this pull request, I am able to wrap grunticon icons in a component, which will then call grunticon.loader.embedIcons(icons, thisDOMnode) after the component is mounted surgically embedding the icons to this DOM node alone.
